### PR TITLE
fix: register accessory under correct plugin identifier

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,6 +1,6 @@
 {
-    "pluginAlias": "Sms77SmsHomebridgePlugin",
-    "pluginType": "platform",
+    "pluginAlias": "Sms77Sms",
+    "pluginType": "accessory",
     "schema": {
         "properties": {
             "apiKey": {

--- a/package.json
+++ b/package.json
@@ -28,5 +28,5 @@
         "type": "git",
         "url": "git://github.com/sms77io/homebridge-sms.git"
     },
-    "version": "0.0.1"
+    "version": "0.0.2"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ module.exports = function(homebridge) {
     Characteristic = homebridge.hap.Characteristic
     Service = homebridge.hap.Service
 
-    homebridge.registerAccessory('homebridge-sms77-sms', 'Sms77Sms', Sms77SmsSwitch)
+    homebridge.registerAccessory('@seven.io/homebridge-sms', 'Sms77Sms', Sms77SmsSwitch)
 }
 
 function Sms77SmsSwitch(log, config) {
@@ -33,7 +33,7 @@ function Sms77SmsSwitch(log, config) {
     if (!this.text) throw new Error('Missing text!')
     if (!this.to) throw new Error('Missing to!')
 
-    this.client = new Client(this.apiKey, 'homebridge-sms')
+    this.client = new Client(this.apiKey, '@seven.io/homebridge-sms')
 
     this.services = {
         AccessoryInformation: new Service.AccessoryInformation(),


### PR DESCRIPTION
## Summary

Plugin v0.0.1 has been unusable since the 2024-10-30 rebrand from `homebridge-sms77-sms` to `@seven.io/homebridge-sms` (commit c498b44). The rename only touched `package.json`/`README.md` - the runtime registration and Homebridge UI schema were left pointing at the old name, so Homebridge logs:

- `Plugin '@seven.io/homebridge-sms' tried to register with an incorrect plugin identifier: 'homebridge-sms77-sms'`
- `No plugin was found for the platform 'Sms77SmsHomebridgePlugin' in your config.json`

Reported by customer (Intercom 215474448958602) with screenshots clearly showing both errors.

## Changes

- `src/index.js`: `registerAccessory` identifier `homebridge-sms77-sms` -> `@seven.io/homebridge-sms` (matches `package.json` name)
- `src/index.js`: `sms77-client` signature string aligned to `@seven.io/homebridge-sms`
- `config.schema.json`: `pluginType: platform` -> `accessory`, `pluginAlias: Sms77SmsHomebridgePlugin` -> `Sms77Sms`. The code has always registered an accessory; the schema was wrong from the start and made the Homebridge UI write a `platforms[]` entry no plugin could claim. `Sms77Sms` matches both the `registerAccessory` accessory name and the README example.
- `package.json`: version bump 0.0.1 -> 0.0.2

## Test plan

- [x] `node -c src/index.js` (syntax check)
- [x] JSON validity of `config.schema.json` / `package.json`
- [ ] Manual: install on a Homebridge box, verify accessory shows up, toggle switch -> SMS sent
- [ ] Publish to npm as 0.0.2 after merge