### PR TITLE
chore(pkg): whitelist published files, ignore scratchpads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 package-lock.json
+.claude/
+scratchpads/

--- a/package.json
+++ b/package.json
@@ -14,6 +14,12 @@
         "homebridge": ">=1.3.0",
         "node": ">=12.13.0"
     },
+    "files": [
+        "src/",
+        "config.schema.json",
+        "LICENSE",
+        "README.md"
+    ],
     "homepage": "https://github.com/sms77io/homebridge-sms",
     "keywords": [
         "homebridge",


### PR DESCRIPTION
## Summary

Caught right before `npm publish 0.0.2`: without a `files` field in `package.json`, npm falls back to gitignore and would have shipped `.claude/`, `scratchpads/` (including customer screenshots from the triage of #8), and `_screenshots/` inside the tarball. 0.0.1 slipped through unnoticed because the working tree was clean back then.

`npm pack --dry-run` before:
- 14 files, 1.5 MB, includes `.claude/scheduled_tasks.lock`, all intercom screenshots, `_screenshots/*.png`

After:
- 5 files, 4 kB: `src/index.js`, `config.schema.json`, `LICENSE`, `README.md`, `package.json`

## Changes

- `package.json`: add `files` whitelist for the four artifacts that actually constitute the plugin
- `.gitignore`: add `.claude/` and `scratchpads/` so the agent workspace stops cluttering `git status`

## Test plan

- [x] `npm pack --dry-run` shows exactly 5 files / 4 kB
- [x] JSON validity (`node -e 'JSON.parse(...)' `)
- [ ] After merge: `pnpm publish --access public` (sister task)